### PR TITLE
Add settings to be able to change the character used to deliminate control statements

### DIFF
--- a/heterocephalus.cabal
+++ b/heterocephalus.cabal
@@ -44,6 +44,7 @@ library
                      , shakespeare >= 2.0 && < 2.1
                      , template-haskell >= 2.7 && < 3
                      , text >= 1.2 && < 1.3
+                     , transformers
   ghc-options:         -Wall
   default-language:    Haskell2010
 

--- a/heterocephalus.cabal
+++ b/heterocephalus.cabal
@@ -33,11 +33,13 @@ library
                      , Text.Heterocephalus.Parse
                      , Text.Heterocephalus.Parse.Control
                      , Text.Heterocephalus.Parse.Doc
+                     , Text.Heterocephalus.Parse.Option
   build-depends:       base >= 4.7 && < 5
                      , blaze-html >= 0.8 && < 0.10
                      , blaze-markup >= 0.7 && < 0.9
                      , containers >= 0.5 && < 0.6
                      , dlist >= 0.7.1.1
+                     , mtl
                      , parsec >= 3.1 && < 3.2
                      , shakespeare >= 2.0 && < 2.1
                      , template-haskell >= 2.7 && < 3

--- a/src/Text/Heterocephalus/Parse.hs
+++ b/src/Text/Heterocephalus/Parse.hs
@@ -9,21 +9,24 @@ module Text.Heterocephalus.Parse
   ( module Text.Heterocephalus.Parse
   , module Text.Heterocephalus.Parse.Control
   , module Text.Heterocephalus.Parse.Doc
+  , module Text.Heterocephalus.Parse.Option
   ) where
 
 import Text.Heterocephalus.Parse.Control (Content(..), parseLineControl)
 import Text.Heterocephalus.Parse.Doc
        (Doc(..), parseDocFromControls)
+import Text.Heterocephalus.Parse.Option
+       (ParseOptions(..), createParseOptions, defaultParseOptions)
 
-docFromString :: String -> [Doc]
-docFromString s =
-  case parseDoc s of
+docFromString :: ParseOptions -> String -> [Doc]
+docFromString opts s =
+  case parseDoc opts s of
     Left s' -> error s'
     Right d -> d
 
-parseDoc :: String -> Either String [Doc]
-parseDoc s = do
-  controls <- parseLineControl s
+parseDoc :: ParseOptions -> String -> Either String [Doc]
+parseDoc opts s = do
+  controls <- parseLineControl opts s
   case parseDocFromControls controls of
     Left parseError -> Left $ show parseError
     Right docs -> Right docs

--- a/src/Text/Heterocephalus/Parse/Option.hs
+++ b/src/Text/Heterocephalus/Parse/Option.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Text.Heterocephalus.Parse.Option where
+
+#if MIN_VERSION_base(4,9,0)
+#else
+import Control.Applicative ((<$>), (*>), (<*), pure)
+#endif
+
+import Control.Monad.Reader (MonadReader, reader)
+
+data ParseOptions = ParseOptions
+  { parseOptionsControlPrefix :: Char
+  , parseOptionsVariablePrefix :: Char
+  }
+
+-- | Default set of parser options.
+--
+-- Sets 'parseOptionsControlPrefix' to @\'%\'@  and
+-- 'parseOptionsVariablePrefix' to @\'#\'@.
+defaultParseOptions :: ParseOptions
+defaultParseOptions = createParseOptions '%' '#'
+
+createParseOptions
+  :: Char  -- ^ The control prefix.
+  -> Char  -- ^ The variable prefix.
+  -> ParseOptions
+createParseOptions controlPrefix varPrefix = ParseOptions
+  { parseOptionsControlPrefix = controlPrefix
+  , parseOptionsVariablePrefix = varPrefix
+  }
+
+getControlPrefix :: MonadReader ParseOptions m => m Char
+getControlPrefix = reader parseOptionsControlPrefix
+
+getVariablePrefix :: MonadReader ParseOptions m => m Char
+getVariablePrefix = reader parseOptionsVariablePrefix

--- a/src/Text/Heterocephalus/Parse/Option.hs
+++ b/src/Text/Heterocephalus/Parse/Option.hs
@@ -3,11 +3,6 @@
 
 module Text.Heterocephalus.Parse.Option where
 
-#if MIN_VERSION_base(4,9,0)
-#else
-import Control.Applicative ((<$>), (*>), (<*), pure)
-#endif
-
 import Control.Monad.Reader (MonadReader, reader)
 
 data ParseOptions = ParseOptions


### PR DESCRIPTION
@syocy Fixes #17.

There is a short example of how to change `HeterocephalusSettings` in the documentation for `Text.Heterocephalus.compileFile`.