### PR TITLE
Fix compile error in GHC 9.2

### DIFF
--- a/heterocephalus.cabal
+++ b/heterocephalus.cabal
@@ -1,5 +1,5 @@
 name:                heterocephalus
-version:             1.0.5.6
+version:             1.0.5.7
 synopsis:            A type-safe template engine for working with front end development tools
 description:
     Recent front end development tools and languages are growing fast and have
@@ -43,7 +43,7 @@ library
                      , parsec >= 3.1
                      , shakespeare >= 2.0
                      , template-haskell >= 2.12
-                     , template-haskell-compat-v0208 >= 0.1.2
+                     , template-haskell-compat-v0208 >= 0.1.9
                      , text >= 1.2
                      , transformers >= 0.5
   ghc-options:         -Wall -Wcompat -Wnoncanonical-monad-instances

--- a/src/Text/Heterocephalus.hs
+++ b/src/Text/Heterocephalus.hs
@@ -575,7 +575,16 @@ bindingPattern (BindList is) = do
   return (ListP patterns, concat scopes)
 bindingPattern (BindConstr con is) = do
   (patterns, scopes) <- fmap unzip $ mapM bindingPattern is
-  return (ConP (mkConName con) patterns, concat scopes)
+  {- 
+  Todo: Note, the use of conP below (note lowercase 'c') is from the package 'template-haskell-compat-v0208'.
+  This allows Heterocephalus to compile with GHC 9.2, as the ConP constructor takes an additional argument in GHC 9.2
+  Note however this _probably_ means there was some new extension or new syntax extension that GHC now allows post GHC 9.2
+  that we are not able to handle. As I (clintonmead@gmail.com) am just writing a PR to the library and don't fully understand it
+  (I'm making this PR just to make our current project build under GHC 9.2) there's probably some more work to be done here.
+
+  The github issue relating to this is at https://github.com/arowM/heterocephalus/issues/32
+  -}
+  return (conP (mkConName con) patterns, concat scopes)
 bindingPattern (BindRecord con fields wild) = do
   let f (Ident field, b) = do
         (p, s) <- bindingPattern b

--- a/stack-lts-lower.yaml
+++ b/stack-lts-lower.yaml
@@ -39,7 +39,8 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- template-haskell-compat-v0208-0.1.9@sha256:abba2d89c500b0ad6259f42be07c1a59d331970624de7e0600ba62738e2c0115,1523
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: nightly-2022-02-25
+resolver: nightly-2022-07-10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
The ConP constructor takes an extra argument in GHC-9.2, and this fix ensures that Heterocephalus compiles for GHC-9.2 whilst continuing to be backwards compatible with pre GHC-9.2. Note that this patch does not introduce logic to handle the new GHC-9.2 syntax (whatever that is), it just ensures that the current behaviour pre GHC-9.2 features can continue to compile under GHC-9.2.